### PR TITLE
file parsing and insertion into database works; using unit18 method i…

### DIFF
--- a/apps/OpenGenomeExplorer/static/js/index.js
+++ b/apps/OpenGenomeExplorer/static/js/index.js
@@ -276,9 +276,34 @@ let init = (app) => {
         file_info: app.file_info,
     };
 
+    app.upload_complete_nogcs = function (file_name, file_type){
+        app.vue.uploading = false;
+        app.vue.upload_done = true;
+        app.vue.uploaded_file = file_name;
+    }
+
+    app.upload_file_nogcs = function (event){
+        let self = this;
+        let input = event.target;
+        let file = input.files[0];
+        if (file) {
+            app.vue.uploading = true;
+            let file_type = file.type;
+            let file_name = file.name;
+            let full_url = file_upload_url + "&file_name=" + encodeURIComponent(file_name) + "&file_type" + encodeURIComponent(file_type);
+            let req = new XMLHttpRequest();
+            req.addEventListener("load", function(){
+                app.upload_complete_nogcs(file_name, file_type);
+            });
+            req.open("PUT", full_url, true);
+            req.send(file);
+        }
+    }
+
     // This contains all the methods.
     app.methods = {
         // Complete as you see fit.
+        upload_file_nogcs: app.upload_file_nogcs,
         upload_file: app.upload_file,
         upload_complete: app.upload_complete,
         get_snps: app.get_snps,

--- a/apps/OpenGenomeExplorer/templates/index.html
+++ b/apps/OpenGenomeExplorer/templates/index.html
@@ -8,11 +8,11 @@
 
 
 <div class="section" id="vue-target" v-cloak>
-  <div v-if="user_snps.length < 1 && hide_upload == false" class="field has-addons">
+  <div class="field has-addons">
     <p class="control">
       <div v-if="!upload_done" class="file is-info">
         <label class="file-label">
-          <input class="file-input" type="file" @change="upload_file($event)">
+          <input class="file-input" type="file" @change="upload_file_nogcs($event)">
           <span class="file-cta">
             <span class="file-icon">
               <i v-if="uploading" class="fa fa-spinner fa-pulse fa-fw"></i>


### PR DESCRIPTION
- created upload_file_nogcs() vue function and py4web route for file upload parsing; upload_file() function untouched but calls are removed

- removed old code inside process_snps(); replaced with regex that only flags rsid lines; tested to work on two differently formatted input SNP files attached below

[11876.23andme.9754_abridged.txt](https://github.com/rodartecode/Open-Genome-Explorer/files/11640396/11876.23andme.9754_abridged.txt)
[11890.ancestry.txt](https://github.com/rodartecode/Open-Genome-Explorer/files/11640397/11890.ancestry.txt)

- Code to fetch information from OpenSNP site using requests module removed (scraping data from SNP site and comparing should not be done in upload_file() function imo; upload_file() already takes a long time for big files and if data scraping is done in same function it might take hours just to upload file. Maybe have another route called "compare_file()", activated with a button press, that compares the user's SNP data with the SNP data that is scraped separately)